### PR TITLE
Add ktfmt to the project

### DIFF
--- a/.fleet/settings.json
+++ b/.fleet/settings.json
@@ -1,0 +1,3 @@
+{
+    "run.destination.stop.already.running": "Always"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ local.properties
 
 # Log/OS Files
 *.log
+.DS_Store
+Thumbs.db
 
 # Android Studio generated files and folders
 captures/
@@ -28,3 +30,14 @@ render.experimental.xml
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json
+
+# Kotlin metadata
+.kotlin
+
+# XCode project
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcodeproj/project.xcworkspace/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,16 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+
+    alias(libs.plugins.ktfmt)
+}
+
+ktfmt {
+    kotlinLangStyle()
+}
+
+val ktfmtCheck = tasks.named("ktfmtCheck")
+
+tasks.register("prePush") {    dependsOn(ktfmtCheck)
+    group = "validation"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,6 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.jetbrainsCompose) apply false
+    alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -60,20 +60,24 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+
     dependencies {
         debugImplementation(libs.compose.ui.tooling)
     }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,15 +1,18 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.composeCompiler)
 }
 
 kotlin {
     androidTarget {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "11"
-            }
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
         }
     }
 
@@ -51,7 +54,7 @@ android {
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
-        applicationId = "com.rahulrav.camera.control"
+        applicationId = namespace
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 1

--- a/composeApp/src/commonMain/kotlin/Camera.kt
+++ b/composeApp/src/commonMain/kotlin/Camera.kt
@@ -1,3 +1,7 @@
+import alpha_shot.composeapp.generated.resources.Res
+import alpha_shot.composeapp.generated.resources.noun_camera_crossed
+import alpha_shot.composeapp.generated.resources.noun_camera_filled
+import alpha_shot.composeapp.generated.resources.noun_camera_outline
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.Spring
@@ -27,28 +31,20 @@ import androidx.compose.ui.layout.ContentScale
 import com.juul.kable.State
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
-import sony_camera_control_mpp.composeapp.generated.resources.Res
-import sony_camera_control_mpp.composeapp.generated.resources.noun_camera_crossed
-import sony_camera_control_mpp.composeapp.generated.resources.noun_camera_filled
-import sony_camera_control_mpp.composeapp.generated.resources.noun_camera_outline
-
 
 enum class CameraStates {
     OTHER,
     CONNECTED
 }
 
-private fun CameraStates.label(): String {
-    return if (this == CameraStates.CONNECTED) {
+private fun CameraStates.label(): String =
+    if (this == CameraStates.CONNECTED) {
         "Connected to Camera"
     } else {
         "Attempting to connect to Camera"
     }
-}
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun Camera(cameraControl: SonyCameraControl) {
     val scope = rememberCoroutineScope()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ junit = "4.13.2"
 kotlin = "2.0.0"
 kable = "0.31.1"
 kermit = "2.0.3"
+ktfmt-plugin = "0.18.0"
+git-hooks-plugin = "2.0.7"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -39,3 +41,5 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-plugin" }
+gitHooks = { id = "org.danilopianini.gradle-pre-commit-git-hooks", version.ref = "git-hooks-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.2"
+agp = "8.3.2"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"
@@ -10,10 +10,10 @@ androidx-core-ktx = "1.13.1"
 androidx-espresso-core = "3.6.1"
 androidx-material = "1.12.0"
 androidx-test-junit = "1.2.1"
-compose = "1.6.8"
-compose-plugin = "1.6.2"
+androidx-ui-tooling = "1.6.8"
+compose-plugin = "1.6.11"
 junit = "4.13.2"
-kotlin = "1.9.23"
+kotlin = "2.0.0"
 kable = "0.31.1"
 kermit = "2.0.3"
 
@@ -28,13 +28,14 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidx-ui-tooling" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-ui-tooling" }
 kable-core = { module = "com.juul.kable:core", version.ref = "kable"}
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pre-push.bat
+++ b/pre-push.bat
@@ -1,0 +1,1 @@
+gradlew :prePush

--- a/pre-push.sh
+++ b/pre-push.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew :prePush

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,19 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.danilopianini.gradle-pre-commit-git-hooks") version "2.0.7"
+}
+
+gitHooks {
+    hook("pre-push") {
+        val extension = if (System.getProperty("os.name").startsWith("Windows")) "bat" else "sh"
+        from(File("pre-push.$extension"))
+    }
+
+    createHooks()
+}
+
 dependencyResolutionManagement {
     repositories {
         google {


### PR DESCRIPTION
[ktfmt](https://github.com/facebook/ktfmt) is an opinionated formatter, like errorprone. It enforces the Kotlinlang official style.

This PR adds it to the project. This means adding a Gradle plugin to run the checks, and another to install a pre-push hook that ensures the code is properly formatted.

To format the project one can use the `ktfmtFormat` task; push will fail if the style doesn't match.

> [!NOTE]
> Follow-up to #1 — needs #1 to be merged first.